### PR TITLE
feat: add mobile layout for projects section

### DIFF
--- a/src/lib/components/sections/ProjectsSection.svelte
+++ b/src/lib/components/sections/ProjectsSection.svelte
@@ -33,7 +33,6 @@
 			<div class="flex flex-col gap-4 lg:hidden">
 				{#each projects as p (p.id)}
 					<ProjectCardMobileComponent
-						id={p.documentId}
 						name={p.title}
 						description={p.description}
 						icon={p.projectIcon?.iconIdentifier}

--- a/src/lib/components/sections/ProjectsSection.svelte
+++ b/src/lib/components/sections/ProjectsSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { getProjects } from '$lib/api/projects.remote';
 	import BentoCardComponent from '$lib/components/shared/BentoCardComponent.svelte';
+	import ProjectCardMobileComponent from '$lib/components/shared/ProjectCardMobileComponent.svelte';
 	import SectionHeader from '$lib/components/shared/SectionHeader.svelte';
 	import { cn } from '$lib/utils';
 	import { getThumbnailImageUrl } from '../shared/util/getThumbnailImageUrl';
@@ -12,7 +13,7 @@
 	<section id="projects" class="bg-black text-white">
 		<div class="container py-8 md:py-16">
 			<SectionHeader title="Projekte" class="pb-8 text-center lg:text-left" />
-			<div class="flex flex-col items-center justify-center gap-24 md:gap-64">
+			<div class="hidden flex-col items-center justify-center gap-24 md:gap-64 lg:flex">
 				<div class="grid w-full auto-rows-[20rem] grid-cols-1 gap-4 lg:grid-cols-3">
 					{#each projects as p (p.id)}
 						<BentoCardComponent
@@ -27,6 +28,20 @@
 						/>
 					{/each}
 				</div>
+			</div>
+
+			<div class="flex flex-col gap-4 lg:hidden">
+				{#each projects as p (p.id)}
+					<ProjectCardMobileComponent
+						id={p.documentId}
+						name={p.title}
+						description={p.description}
+						icon={p.projectIcon?.iconIdentifier}
+						href="/projects/{p.slug}"
+						cta="Mehr"
+						backgroundImgUrl={getThumbnailImageUrl(p.teaserImage)}
+					/>
+				{/each}
 			</div>
 		</div>
 	</section>

--- a/src/lib/components/shared/ProjectCardMobileComponent.svelte
+++ b/src/lib/components/shared/ProjectCardMobileComponent.svelte
@@ -24,12 +24,11 @@
 	data-sveltekit-preload-data="tap"
 >
 	{#if !!backgroundImgUrl}
-		<div class="w-44 shrink-0 self-stretch overflow-hidden">
-			<img
-				src={backgroundImgUrl}
-				alt={name}
-				class="h-full w-full object-cover object-center transition-all duration-300 group-hover:scale-103"
-			/>
+		<div class="relative w-44 shrink-0 self-stretch overflow-hidden">
+			<div
+				class="absolute inset-0 bg-cover bg-center transition-transform duration-300 group-hover:scale-103"
+				style:background-image={`url(${backgroundImgUrl})`}
+			></div>
 		</div>
 	{/if}
 

--- a/src/lib/components/shared/ProjectCardMobileComponent.svelte
+++ b/src/lib/components/shared/ProjectCardMobileComponent.svelte
@@ -2,7 +2,6 @@
 	import Icon from '@iconify/svelte';
 
 	const {
-		id,
 		name,
 		href,
 		description,
@@ -10,7 +9,6 @@
 		icon,
 		backgroundImgUrl
 	}: {
-		id: string;
 		name: string;
 		href: string;
 		description: string;
@@ -21,7 +19,6 @@
 </script>
 
 <a
-	{id}
 	{href}
 	class="group flex w-full transform-gpu flex-row items-stretch overflow-hidden rounded-xl border border-white/10 bg-black transition-all active:scale-98"
 	data-sveltekit-preload-data="tap"
@@ -30,7 +27,7 @@
 		<div class="aspect-[4/3] w-32 shrink-0 self-center overflow-hidden">
 			<img
 				src={backgroundImgUrl}
-				alt="background"
+				alt={name}
 				class="h-full w-full object-cover object-center transition-all duration-300 group-hover:scale-103"
 			/>
 		</div>

--- a/src/lib/components/shared/ProjectCardMobileComponent.svelte
+++ b/src/lib/components/shared/ProjectCardMobileComponent.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import Icon from '@iconify/svelte';
+
+	const {
+		id,
+		name,
+		href,
+		description,
+		cta,
+		icon,
+		backgroundImgUrl
+	}: {
+		id: string;
+		name: string;
+		href: string;
+		description: string;
+		cta: string;
+		icon?: string;
+		backgroundImgUrl?: string;
+	} = $props();
+</script>
+
+<a
+	{id}
+	{href}
+	class="group flex w-full transform-gpu flex-row items-stretch overflow-hidden rounded-xl border border-white/10 bg-black transition-all active:scale-98"
+	data-sveltekit-preload-data="tap"
+>
+	{#if !!backgroundImgUrl}
+		<div class="aspect-[4/3] w-32 shrink-0 self-center overflow-hidden">
+			<img
+				src={backgroundImgUrl}
+				alt="background"
+				class="h-full w-full object-cover object-center transition-all duration-300 group-hover:scale-103"
+			/>
+		</div>
+	{/if}
+
+	<div class="flex min-w-0 flex-1 flex-col justify-center gap-1 p-4">
+		<div class="flex flex-row items-center gap-1.5">
+			{#if !!icon}
+				<Icon
+					{icon}
+					class="-ml-0.5 shrink-0 text-xl text-neutral-700 transition-all group-hover:text-neutral-400"
+				/>
+			{/if}
+			<h3 class="truncate font-bold text-white">
+				{name}
+			</h3>
+		</div>
+		<p class="line-clamp-2 text-sm text-neutral-400 transition-colors group-hover:text-white">
+			{description}
+		</p>
+		<span class="mt-1 flex items-center text-xs text-neutral-500">
+			{cta}
+			<Icon icon="ic:baseline-arrow-forward" />
+		</span>
+	</div>
+</a>

--- a/src/lib/components/shared/ProjectCardMobileComponent.svelte
+++ b/src/lib/components/shared/ProjectCardMobileComponent.svelte
@@ -24,7 +24,7 @@
 	data-sveltekit-preload-data="tap"
 >
 	{#if !!backgroundImgUrl}
-		<div class="aspect-[4/3] w-32 shrink-0 self-center overflow-hidden">
+		<div class="w-44 shrink-0 self-stretch overflow-hidden">
 			<img
 				src={backgroundImgUrl}
 				alt={name}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,7 +7,6 @@
 	import '../app.css';
 
 	const { children }: { children: Snippet } = $props();
-
 </script>
 
 <svelte:head>

--- a/src/routes/blogs/[slug]/+page.svelte
+++ b/src/routes/blogs/[slug]/+page.svelte
@@ -58,11 +58,7 @@
 					{blog.title}
 				</h1>
 				{#if blog.teaserImage}
-					<img
-						src={blog.teaserImage?.url}
-						alt={blog.title}
-						class="w-full"
-					/>
+					<img src={blog.teaserImage?.url} alt={blog.title} class="w-full" />
 				{/if}
 				<div class="motion-preset-slide-up-sm motion-delay-50 motion-duration-500">
 					<!-- eslint-disable svelte/no-at-html-tags -->

--- a/src/routes/blogs/[slug]/+page.svelte
+++ b/src/routes/blogs/[slug]/+page.svelte
@@ -7,7 +7,7 @@
 	import { cn } from '$lib/utils';
 
 	const { params } = $props();
-	const { blog } = await getBlobBySlug(params.slug);
+	const { blog } = $derived(await getBlobBySlug(params.slug));
 
 	const serifFont = serifStore;
 </script>

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -7,7 +7,7 @@
 	import Icon from '@iconify/svelte';
 
 	const { params } = $props();
-	const { project } = await getProjectBySlug(params.slug);
+	const { project } = $derived(await getProjectBySlug(params.slug));
 
 	const serifFont = serifStore;
 </script>


### PR DESCRIPTION
## Summary

Adds a dedicated mobile layout for the Projekte section. Previously the desktop bento grid collapsed to a single column of 20rem tiles with large `gap-24` spacing on narrow screens, which read poorly.

- Desktop bento grid + `BentoCardComponent` are unchanged and now gated to `lg` and up (`hidden … lg:flex`).
- Below `lg`, a new compact list layout renders `ProjectCardMobileComponent`: full-color 4:3 thumbnail, icon + title, 2-line clamped description, and CTA, stacked with tight `gap-4`.
- Mobile card mirrors the bento hover/active styling (image `scale-103`, icon/description color shift, `active:scale-98`).

## Validation

- `pnpm check` — 0 errors
- `vitest run` — 64/64 passing
- `eslint` — clean on changed files
- `prettier` — changed files formatted

Note: unrelated `package.json`/`pnpm-lock.yaml` (`devEngines`) changes present in the working tree were intentionally excluded from this PR.